### PR TITLE
Fix memory leak during reach set computation

### DIFF
--- a/cpp/include/reachset/data_structure/reach/reach_node.hpp
+++ b/cpp/include/reachset/data_structure/reach/reach_node.hpp
@@ -12,8 +12,8 @@ namespace reach {
 class ReachNode {
 private:
     static int cnt_id;
-    std::vector<std::shared_ptr<ReachNode>> _vec_nodes_parent;
-    std::vector<std::shared_ptr<ReachNode>> _vec_nodes_child;
+    std::vector<std::weak_ptr<ReachNode>> _vec_nodes_parent;
+    std::vector<std::weak_ptr<ReachNode>> _vec_nodes_child;
 
     /// Check whether it is necessary to perform a halfspace intersection given current and target bounds.
     /// @param current current bound of the polygon
@@ -73,9 +73,23 @@ public:
 
     inline bool is_empty() const { return polygon_lon->empty() || polygon_lat->empty(); }
 
-    inline std::vector<std::shared_ptr<ReachNode>> vec_nodes_parent() const { return this->_vec_nodes_parent; };
+    inline std::vector<std::shared_ptr<ReachNode>> vec_nodes_parent() const { 
+        std::vector<std::shared_ptr<ReachNode>> vec_nodes_parent_shared;
+        for (auto const& elem : this->_vec_nodes_parent)
+        {
+            vec_nodes_parent_shared.emplace_back(elem.lock());
+        }
+        return vec_nodes_parent_shared;
+    };
 
-    inline std::vector<std::shared_ptr<ReachNode>> vec_nodes_child() const { return this->_vec_nodes_child; };
+    inline std::vector<std::shared_ptr<ReachNode>> vec_nodes_child() const { 
+        std::vector<std::shared_ptr<ReachNode>> vec_nodes_child_shared;
+        for (auto const& elem : this->_vec_nodes_child)
+        {
+            vec_nodes_child_shared.emplace_back(elem.lock());
+        }
+        return vec_nodes_child_shared;
+    };
 
     /// Rectangle representing the projection of the node onto the position domain.
     inline ReachPolygonPtr position_rectangle() const {
@@ -83,11 +97,11 @@ public:
                                               p_lon_max(), p_lat_max());
     }
 
-    inline void assign_parent_nodes(std::vector<std::shared_ptr<ReachNode>> const& vec_nodes_parent) {
+    inline void assign_parent_nodes(std::vector<std::weak_ptr<ReachNode>> const& vec_nodes_parent) {
         _vec_nodes_parent = vec_nodes_parent;
     }
 
-    void assign_child_nodes(std::vector<std::shared_ptr<ReachNode>> const& vec_nodes_child) {
+    void assign_child_nodes(std::vector<std::weak_ptr<ReachNode>> const& vec_nodes_child) {
         _vec_nodes_child = vec_nodes_child;
     }
 

--- a/cpp/src/data_structure/reach/reach_node.cpp
+++ b/cpp/src/data_structure/reach/reach_node.cpp
@@ -14,8 +14,9 @@ ReachNode::ReachNode(int const& step, ReachPolygonPtr polygon_lon, ReachPolygonP
 
 bool ReachNode::add_parent_node(ReachNodePtr const& node_parent) {
     if (std::none_of(_vec_nodes_parent.cbegin(), _vec_nodes_parent.cend(),
-                     [&](auto const& node) { return node == node_parent; })) {
-        _vec_nodes_parent.emplace_back(node_parent);
+                     [&](auto const& node) { return node.lock() == node_parent; })) {
+        std::weak_ptr<ReachNode> node_parent_weak_ptr = node_parent;
+        _vec_nodes_parent.emplace_back(node_parent_weak_ptr);
         return true;
     }
 
@@ -24,7 +25,9 @@ bool ReachNode::add_parent_node(ReachNodePtr const& node_parent) {
 
 
 bool ReachNode::remove_parent_node(ReachNodePtr const& node_parent) {
-    auto it_end = std::remove(_vec_nodes_parent.begin(), _vec_nodes_parent.end(), node_parent);
+    auto it_end = std::remove_if(_vec_nodes_parent.begin(), _vec_nodes_parent.end(), [&node_parent](const std::weak_ptr<ReachNode>& weakPtr) {
+            return weakPtr.lock() == node_parent; // Compare using lock()
+    });
     if (it_end != _vec_nodes_parent.end()) {
         _vec_nodes_parent.erase(it_end, _vec_nodes_parent.end());
         return true;
@@ -36,8 +39,9 @@ bool ReachNode::remove_parent_node(ReachNodePtr const& node_parent) {
 bool ReachNode::add_child_node(ReachNodePtr const& node_child) {
     if (std::none_of(_vec_nodes_child.cbegin(),
                      _vec_nodes_child.cend(),
-                     [&](auto const& node) { return node == node_child; })) {
-        _vec_nodes_child.emplace_back(node_child);
+                     [&](auto const& node) { return node.lock() == node_child; })) {
+        std::weak_ptr<ReachNode> node_child_weak_ptr = node_child;
+        _vec_nodes_child.emplace_back(node_child_weak_ptr);
         return true;
     }
 
@@ -45,7 +49,9 @@ bool ReachNode::add_child_node(ReachNodePtr const& node_child) {
 }
 
 bool ReachNode::remove_child_node(ReachNodePtr const& node_child) {
-    auto it_end = std::remove(_vec_nodes_child.begin(), _vec_nodes_child.end(), node_child);
+    auto it_end = std::remove_if(_vec_nodes_child.begin(), _vec_nodes_child.end(), [&node_child](const std::weak_ptr<ReachNode>& weakPtr) {
+            return weakPtr.lock() == node_child; // Compare using lock()
+    });
     if (it_end != _vec_nodes_child.end()) {
         _vec_nodes_child.erase(it_end, _vec_nodes_child.end());
         return true;

--- a/cpp/src/data_structure/reach/reach_set.cpp
+++ b/cpp/src/data_structure/reach/reach_set.cpp
@@ -192,7 +192,8 @@ default(none) shared(vec_nodes, vec_base_sets_propagated)
                 auto base_set_propagated = make_shared<ReachNode>(node->step,
                                                                   polygon_lon_propagated,
                                                                   polygon_lat_propagated);
-                base_set_propagated->vec_nodes_source.emplace_back(node);
+                std::weak_ptr<ReachNode> node_weak_ptr = node;
+                base_set_propagated->vec_nodes_source.emplace_back(node_weak_ptr);
                 vec_base_sets_propagated_thread.emplace_back(base_set_propagated);
             }
             catch (std::exception& e) {


### PR DESCRIPTION
* There is a memory leak caused by the usage of shared_ptr<ReachNode> in the child and parent list of ReachNode.
* Replace usage of shared_ptr in the vectors by weak_ptr to avoid circular ownership.
* All reach nodes are now correctly deconstructed after the containing ReachSet is out of scope.